### PR TITLE
Added support for snapshot URL /?snapshot for Octolapse

### DIFF
--- a/webcam.py
+++ b/webcam.py
@@ -21,6 +21,12 @@ capture=None
 
 class CamHandler(BaseHTTPRequestHandler):
   def do_GET(self):
+    if self.path == '/?snapshot':
+      self.sendSnapshot()
+    else:
+      self.streamVideo()
+
+  def streamVideo(self):
     self.send_response(200)
     self.send_header('Content-type', 'multipart/x-mixed-replace; boundary=--jpgboundary')
     self.end_headers()
@@ -40,6 +46,22 @@ class CamHandler(BaseHTTPRequestHandler):
         time.sleep(0.05)
       except:
         break
+
+  def sendSnapshot(self):
+    self.send_response(200)
+    try:
+      rc,img = capture.read()
+      if not rc:
+        return
+      jpg = Image.fromarray(img)
+      tmpFile = BytesIO()
+      jpg.save(tmpFile, "JPEG")
+      self.send_header('Content-type', 'image/jpeg')
+      self.send_header('Content-length', str( len(tmpFile.getvalue()) ))
+      self.end_headers()
+      self.wfile.write( tmpFile.getvalue() )
+    except:
+      pass
  
 class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
   """Handle requests in a separate thread."""


### PR DESCRIPTION
This implements a URL to grab a single jpeg frame, as required by Octolapse.

I have my haproxy set to route requests with the prefix /webcam/ to the stream server in this repository. Here is what it looks like in the octoprint interface (http://octoprint/#tab_plugin_octolapse)

![image](https://user-images.githubusercontent.com/2094779/173694144-ee3581f5-17c2-4d47-94dd-8d95405ef81a.png)
